### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The aim of this project is to build a library that can be used to replace jQuery
 [View Demo](https://jsfiddle.net/markentingh/L2o0qrwy/)
 
 ### Add to your project via public CDN from jsDelivr
-[https://cdn.jsdelivr.net/selectorjs/0.9.12/selector.min.js](https://cdn.jsdelivr.net/selectorjs/0.9.12/selector.min.js)
+[https://cdn.jsdelivr.net/npm/selectorjs@0.9.12/dist/selector.min.js](https://cdn.jsdelivr.net/npm/selectorjs@0.9.12/dist/selector.min.js)
 
 ### File size comparison between jQuery and selector.js
 


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the links now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/selectorjs.

Feel free to ping me if you have any questions regarding this change.